### PR TITLE
Add open graph tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,13 @@
     <title>ReactFest</title>
     <link rel="icon" type="image/png" sizes="32x32" href="<%= htmlWebpackPlugin.files.publicPath %>static/img/icons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="<%= htmlWebpackPlugin.files.publicPath %>static/img/icons/favicon-16x16.png">
+    
+    <!-- open graph tags -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="ReactFest">
+    <meta property="og:description" content="A One Day Festival of Amazing React Content. Single track. 200 developers. Non-profit. By the community for the community.">
+    <meta property="og:image" content="<%= htmlWebpackPlugin.files.publicPath %>static/img/icons/ms-icon-310x310.png">
+    
     <!--[if IE]><link rel="shortcut icon" href="/static/img/icons/favicon.ico"><![endif]-->
     <!-- Add to home screen for Android and modern mobile browsers -->
     <link rel="manifest" href="<%= htmlWebpackPlugin.files.publicPath %>static/manifest.json">


### PR DESCRIPTION
This pull request adds the most commonly used open graph tags.

For the `og:image` I used the largest icon available.